### PR TITLE
docs: add proper README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jacopo Bellosi, Arina Iusupova, Amir Hanna, Pat, Deyvla2, JulieL999
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,46 @@
-# StudyMate, Your favourite study companion
+# StudyMate
 
-Group project for Advanced Software Engineering course at AAU.
+A microservices-based study companion that helps students take, summarize, paraphrase, and transcribe notes. Built as a group project for the Advanced Software Engineering course at AAU.
 
-To run the application:
-- run `docker compose up --build`
-- navigate to `http://localhost:3000/`
+## Architecture
+
+The system is composed of eight Docker containers orchestrated via `docker-compose`:
+
+| Service | Description | Stack |
+|---------|-------------|-------|
+| `frontend` | Single-page web UI | React 18 / TypeScript / Vite |
+| `api-gateway` | Reverse proxy routing requests to backend services | Nginx |
+| `user-management` | Authentication and JWT-based session handling | Python / FastAPI |
+| `summarizing-tool` | Text summarization via a local LLM | FastAPI + Ollama (Llama 3) |
+| `paraphrasing-tool` | Paraphrasing via OpenAI API | Python / FastAPI |
+| `character-recognition` | Handwriting OCR from uploaded images | Python / FastAPI |
+| `voice-transcription` | Speech-to-text from audio uploads | Python / Vosk |
+| `ollama` | Local model server for the summarizer | Ollama |
+
+## Tech stack
+
+- **Frontend:** React 18, TypeScript, Vite, Bootstrap 5
+- **Backend services:** Python, FastAPI, Poetry
+- **ML / AI:** Ollama (Llama 3), OpenAI API, Vosk
+- **Infrastructure:** Docker, docker-compose, Nginx
+- **CI:** GitHub Actions (character-recognition, voice-transcription)
+
+## Getting started
+
+```bash
+# Clone the repository
+git clone https://github.com/jacopobellosi/StudyMate---ASE-project.git
+cd StudyMate---ASE-project
+
+# Start all services
+docker compose up --build
+
+# Open the app
+# http://localhost:3000
+```
+
+The paraphrasing service requires an `OPENAI_API_KEY` environment variable (set it in a `.env` file or export it before running).
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Rewrites README with architecture table, tech stack, and getting-started instructions
- Adds MIT license covering all contributors

## Changes
- `README.md`: full rewrite with microservices architecture overview
- `LICENSE`: MIT (2024, all contributors)